### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ RUN chmod +x /docker-entrypoint.sh
 RUN chmod +x /init-db.sh
 RUN chmod +x server/php/shell/main.sh
 
+# Default ports
+EXPOSE 80
+
 # TODO root user should be avoided but required for now
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
add default expose port

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add EXPOSE into Dockerfile

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/RestyaPlatform/board/issues/4233

## Motivation and Context
let traefik detect default port to communicate, and it's recommanded to do.

## How Has This Been Tested?
start up a container and `docker ps` will show it in ports column

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
